### PR TITLE
[observe -> how-to -> log-your-application -> add-attachments] adds code snippet for adding attachments using JS/TS SDK

### DIFF
--- a/observe/how-to/log-your-application/add-attachments.mdx
+++ b/observe/how-to/log-your-application/add-attachments.mdx
@@ -26,6 +26,35 @@ You can attach files or URLs to both traces and spans. There are three main type
 ### Example: Add Attachments to a Trace
 
 <CodeGroup>
+```typescript JS/TS
+// Create a new trace
+const trace = logger.trace({ id: uuid() });
+trace.input("test input");
+
+// Attach a local file
+trace.addAttachment({
+	id: uuid(),
+	type: "file",
+	path: "./files/wav_audio.wav",
+});
+
+// Attach a remote file or image by URL
+trace.addAttachment({
+	id: uuid(),
+	type: "url",
+	url: "https://sample-image.com/test-image",
+});
+
+// Attach a data blob (e.g., in-memory text)
+trace.addAttachment({
+	id: uuid(),
+	type: "fileData",
+	name: "greeting.txt",
+	data: Buffer.from("Hello world"),
+	mimeType: "text/plain",
+});
+```
+
 ```python Python
 from uuid import uuid4
 from maxim.logger import FileAttachment, UrlAttachment, FileDataAttachment
@@ -45,7 +74,7 @@ trace.add_attachment(FileDataAttachment(data=b'Hello World', name='greeting.txt'
 ```
 </CodeGroup>
 
-**Tip:**  
+**Tip:**
 You can also add attachments to a `span` or `generation` by replacing `trace` with your span or generation object.
 
 ## Notes


### PR DESCRIPTION
# Add JavaScript/TypeScript example for adding attachments to traces

This PR adds a JavaScript/TypeScript code example showing how to add attachments to traces. The example demonstrates three attachment types:

1. Local file attachments
2. Remote file/image attachments via URL
3. Data blob attachments

The new example complements the existing Python example, providing developers using JS/TS with clear guidance on implementing attachment functionality.
