### PR TITLE
removes references

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -298,78 +298,7 @@
                             },                            
                             "sdk/python/upgrading-to-v3"
                         ]
-                    },
-                    {
-                        "group": "Typescript",
-                        "pages": [
-                            {
-                                "group": "Reference",
-                                "pages": [
-                                    "sdk/typescript/reference/overview",
-                                    "sdk/typescript/reference/modules",
-                                    "sdk/typescript/reference/langchain/overview",
-                                    {
-                                        "group": "LangChain",
-                                        "pages": [
-                                            "sdk/typescript/reference/langchain/classes/MaximLangchainTracer"
-                                        ]
-                                    },
-                                    "sdk/typescript/reference/core/overview",
-                                    {
-                                        "group": "Classes",
-                                        "pages": [
-                                            "sdk/typescript/reference/core/classes/BaseContainer",
-                                            "sdk/typescript/reference/core/classes/CSVFile",
-                                            "sdk/typescript/reference/core/classes/CommitLog",
-                                            "sdk/typescript/reference/core/classes/Error",
-                                            "sdk/typescript/reference/core/classes/EvaluatableBaseContainer",
-                                            "sdk/typescript/reference/core/classes/EvaluateContainer",
-                                            "sdk/typescript/reference/core/classes/EventEmittingBaseContainer",
-                                            "sdk/typescript/reference/core/classes/Generation",
-                                            "sdk/typescript/reference/core/classes/LogWriter",
-                                            "sdk/typescript/reference/core/classes/Maxim",
-                                            "sdk/typescript/reference/core/classes/MaximLogger",
-                                            "sdk/typescript/reference/core/classes/MaximLogsAPI",
-                                            "sdk/typescript/reference/core/classes/QueryBuilder",
-                                            "sdk/typescript/reference/core/classes/Retrieval",
-                                            "sdk/typescript/reference/core/classes/Session",
-                                            "sdk/typescript/reference/core/classes/Span",
-                                            "sdk/typescript/reference/core/classes/ToolCall",
-                                            "sdk/typescript/reference/core/classes/Trace"
-                                        ]
-                                    },
-                                    {
-                                        "group": "Interfaces",
-                                        "pages": [
-                                            "sdk/typescript/reference/core/interfaces/ChatCompletionChoice",
-                                            "sdk/typescript/reference/core/interfaces/ChatCompletionMessage",
-                                            "sdk/typescript/reference/core/interfaces/ChatCompletionResult",
-                                            "sdk/typescript/reference/core/interfaces/ChatCompletionToolCall",
-                                            "sdk/typescript/reference/core/interfaces/CompletionRequest",
-                                            "sdk/typescript/reference/core/interfaces/GenerationError",
-                                            "sdk/typescript/reference/core/interfaces/Logprobs",
-                                            "sdk/typescript/reference/core/interfaces/MaximCache",
-                                            "sdk/typescript/reference/core/interfaces/TestRunLogger",
-                                            "sdk/typescript/reference/core/interfaces/TextCompletionChoice",
-                                            "sdk/typescript/reference/core/interfaces/TextCompletionResult",
-                                            "sdk/typescript/reference/core/interfaces/ToolCallConfig",
-                                            "sdk/typescript/reference/core/interfaces/ToolCallError",
-                                            "sdk/typescript/reference/core/interfaces/ToolCallFunction",
-                                            "sdk/typescript/reference/core/interfaces/Usage"
-                                        ]
-                                    },
-                                    {
-                                        "group": "Enumerations",
-                                        "pages": [
-                                            "sdk/typescript/reference/core/enumerations/Entity",
-                                            "sdk/typescript/reference/core/enumerations/QueryRuleType",
-                                            "sdk/typescript/reference/core/enumerations/VariableType"
-                                        ]
-                                    }
-                                ]
-                            }
-                        ]
-                    }
+                    }                   
                 ]
             },
             {


### PR DESCRIPTION
### TL;DR

Removed TypeScript SDK documentation section from docs.json

### What changed?

Removed the entire TypeScript section from the documentation structure, including all reference pages for TypeScript SDK modules, classes, interfaces, and enumerations. This removes documentation for the TypeScript SDK, LangChain integration, and all related TypeScript components.

### How to test?

1. Build the documentation site
2. Verify that the TypeScript SDK section no longer appears in the navigation
3. Confirm that the Python SDK documentation remains intact

### Why make this change?

This change likely reflects a decision to either deprecate the TypeScript SDK or move its documentation to a different location. The removal streamlines the documentation structure by focusing on the remaining supported SDKs.