### PR TITLE
overview fix

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -864,11 +864,7 @@
         {
             "source": "/observe/quickstart#2-generate-api-key",
             "destination": "/settings/maxim-api-keys"
-        },
-        {
-            "source": "/sdk/overview",
-            "destination": "/sdk/overview"
-        }
+        }    
     ],
     "footer": {
         "socials": {

--- a/sdk/overview.mdx
+++ b/sdk/overview.mdx
@@ -1,4 +1,3 @@
-
 ---
 title: "Introduction"
 description: "Dive into the Maxim SDK to supercharge your AI application development"
@@ -18,3 +17,55 @@ Maxim SDK exposes Maxim's most critical functionalities behind a simple set of f
 | Javascript Langchain | [npm](https://www.npmjs.com/package/@maximai/maxim-js-langchain)      | `npm install @maximai/maxim-js-langchain` |
 | Go                   | [Go SDK](https://github.com/maximhq/maxim-go)                         | `go get github.com/maximhq/maxim-go`      |
 | Java/JVM             | [Java/JVM SDK](https://central.sonatype.com/artifact/ai.getmaxim/sdk) | `implementation("ai.getmaxim:sdk:0.1.3")` |
+
+
+## Initializing SDK
+
+<CodeGroup>
+
+```typescript JS/TS
+import { Maxim } from "@maximai/maxim-js"
+
+const maxim = new Maxim({ apiKey: "" });
+```
+
+
+```python Python
+from maxim import Maxim
+
+maxim = Maxim({api_key:""})
+```
+
+
+```go Go
+import "github.com/maximhq/maxim-go"
+
+mx := maxim.Init(&maxim.MaximSDKConfig{ApiKey: ""})
+```
+
+
+```kotlin Java/Kotlin
+import ai.getmaxim.sdk.Maxim;
+import ai.getmaxim.sdk.Config;
+
+var maxim = Maxim(Config(apiKey = ""))
+```
+
+</CodeGroup>
+
+## Whats next?
+
+<CardGroup cols={2}>
+  <Card title="Prompt management using Maxim" icon="terminal" href="/evaluate/how-to/evaluate-prompts/deploy-prompts">
+    
+  </Card>
+  <Card title="Dataset management using Maxim" icon="table" href="/library/how-to/datasets/add-new-entries-using-sdk">
+    
+  </Card>
+  <Card title="Observe and evaluate your production logs realtime using Maxim." icon="tower-observation" href="/observe/overview">
+    
+  </Card>
+  <Card title="Run tests using Maxim SDK." icon="box" href="/evaluate/how-to/trigger-test-runs-using-sdk">
+    
+  </Card>
+</CardGroup>


### PR DESCRIPTION
### TL;DR

Removed redundant redirect entry from docs.json

### What changed?

Removed a self-referential redirect entry from the redirects array in docs.json. The entry was redirecting `/sdk/overview` to itself, which is unnecessary.

### How to test?

1. Verify that the docs build correctly without errors
2. Confirm that navigating to `/sdk/overview` still works as expected
3. Check that no broken links appear in the documentation

### Why make this change?

This change removes redundant configuration that serves no purpose. Self-referential redirects add unnecessary processing overhead and can cause confusion in the redirect chain. Keeping the redirect configuration clean improves maintainability.