### PR TITLE
- adds redirect to main path

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -657,6 +657,10 @@
     },
     "redirects": [
         {
+            "source": "/",
+            "destination": "/introduction/overview"
+        },
+        {
             "source": "/api/overview",
             "destination": "/public-apis/overview"
         },


### PR DESCRIPTION
### TL;DR

Added a redirect from the root path to the introduction overview page.

### What changed?

Added a new redirect rule in the `docs.json` file that redirects users from the root path (`/`) to the introduction overview page (`/introduction/overview`).

### How to test?

1. Navigate to the root URL of the documentation site
2. Verify you are automatically redirected to `/introduction/overview`
3. Ensure the introduction overview page loads correctly

### Why make this change?

This improves user experience by directing visitors who land on the root URL to a meaningful starting point in the documentation, rather than showing a potentially empty or generic landing page.