### PR TITLE
self canonical links

### DIFF
--- a/selfCanonical.js
+++ b/selfCanonical.js
@@ -1,0 +1,24 @@
+document.addEventListener('DOMContentLoaded', () => {
+    try {
+        const url = new URL(window.location.href);
+        if (!['http:', 'https:'].includes(url.protocol)) {
+            console.warn('selfCanonical: Non-HTTP(S) URL detected, skipping canonical link creation');
+            return;
+        }
+        url.search = '';
+        url.hash = '';
+        const existing = document.querySelector('link[rel="canonical"]');
+        if (existing) {
+            existing.href = url.toString();
+        } else {
+            const link = document.createElement('link');
+            link.rel = 'canonical';
+            link.href = url.toString();
+            document.head.appendChild(link);
+        }
+    } catch (error) {
+        console.error('Failed to set canonical URL:', error);
+        // Fallback: ensure we don't break page functionality
+        // The page will continue to work without the canonical link
+    }
+});


### PR DESCRIPTION
### TL;DR

Add self-canonical link to prevent duplicate content issues with URL parameters.

### What changed?

Added a new JavaScript file `selfCanonical.js` that dynamically creates a canonical link element pointing to the current URL without search parameters. The script:
1. Gets the current URL
2. Removes any search parameters
3. Creates a canonical link element
4. Sets the href to the clean URL
5. Appends the link to the document head

### How to test?

1. Include this script in a page with URL parameters (e.g., `example.com/page?param=value`)
2. Inspect the page's HTML head
3. Verify a canonical link pointing to the base URL without parameters (e.g., `example.com/page`) has been added

### Why make this change?

Canonical links help search engines understand which URL is the preferred version when the same content can be accessed through multiple URLs (like with different query parameters). This prevents duplicate content issues and improves SEO by consolidating ranking signals to a single URL.