### PR TITLE
[Tab Title] adds js sdk case for suffix

### DIFF
--- a/title-updater.js
+++ b/title-updater.js
@@ -1,26 +1,39 @@
-// Custom script to update page titles with Maxim Python SDK suffix
+// Custom script to update page titles with Maxim SDK suffix
 (function () {
-    function isPythonSDKPage() {
-        // Check if current page is a Python SDK reference page
+    function getSDKType() {
+        // Check if current page is an SDK reference page and return the SDK type
         const currentPath = window.location.pathname;
 
-        // Check if the path matches Python SDK reference patterns
-        return currentPath.includes('/sdk/python');
+        // Check for Python SDK reference pages
+        if (currentPath.includes("/sdk/python")) {
+            return "python";
+        }
+
+        // Check for TypeScript SDK reference pages
+        if (currentPath.includes("/sdk/typescript")) {
+            return "typescript";
+        }
+
+        // Not an SDK page
+        return null;
     }
 
     function updatePageTitle() {
-        // Only update title if this is a Python SDK page
-        if (!isPythonSDKPage()) {
+        const sdkType = getSDKType();
+
+        // Only update title if this is an SDK page
+        if (!sdkType) {
             return;
         }
 
         // Get the current page title from the frontmatter or h1
-        const titleElement = document.querySelector('h1') || document.querySelector('[data-title]');
-        let pageTitle = '';
+        const titleElement =
+            document.querySelector("h1") || document.querySelector("[data-title]");
+        let pageTitle = "";
 
         // Try to get title from various sources
         if (titleElement) {
-            pageTitle = titleElement.textContent || titleElement.innerText || '';
+            pageTitle = titleElement.textContent || titleElement.innerText || "";
         }
 
         // Fallback to document title if no h1 found
@@ -31,19 +44,29 @@
         // Clean up the title (remove extra whitespace)
         pageTitle = pageTitle.trim();
 
+        // Determine the appropriate suffix based on SDK type
+        const suffix =
+            sdkType === "python" ? "| Maxim Python SDK" : "| Maxim TypeScript SDK";
+
         // Only update if we have a meaningful title and it doesn't already include our suffix
-        if (pageTitle && !pageTitle.includes('| Maxim Python SDK')) {
-            // Remove any existing suffixes that might be there
-            pageTitle = pageTitle.replace(/\s*\|.*$/, '');
+        if (pageTitle && !pageTitle.includes(suffix)) {
+            // Remove any existing SDK suffixes that might be there
+            pageTitle = pageTitle.replace(
+                /\s*\|\s*Maxim\s+(Python|TypeScript)\s+SDK.*$/,
+                "",
+            );
+
+            // Also remove any other existing suffixes
+            pageTitle = pageTitle.replace(/\s*\|.*$/, "");
 
             // Add our custom suffix
-            document.title = pageTitle + ' | Maxim Python SDK';
+            document.title = pageTitle + " " + suffix;
         }
     }
 
     // Update title when page loads
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', updatePageTitle);
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", updatePageTitle);
     } else {
         updatePageTitle();
     }
@@ -62,23 +85,28 @@
             setTimeout(updatePageTitle, 100);
         };
 
-        window.addEventListener('popstate', function () {
+        window.addEventListener("popstate", function () {
             setTimeout(updatePageTitle, 100);
         });
     }
 
     // Watch for title changes using MutationObserver
-    if (typeof MutationObserver !== 'undefined') {
+    if (typeof MutationObserver !== "undefined") {
         const observer = new MutationObserver(function (mutations) {
             mutations.forEach(function (mutation) {
-                if (mutation.type === 'childList' || mutation.type === 'characterData') {
+                if (
+                    mutation.type === "childList" ||
+                    mutation.type === "characterData"
+                ) {
                     // Check if title-related elements changed
-                    const titleChanged = Array.from(mutation.addedNodes).some(node =>
-                        node.nodeType === Node.ELEMENT_NODE &&
-                        (node.tagName === 'H1' || node.querySelector && node.querySelector('h1'))
+                    const titleChanged = Array.from(mutation.addedNodes).some(
+                        (node) =>
+                            node.nodeType === Node.ELEMENT_NODE &&
+                            (node.tagName === "H1" ||
+                                (node.querySelector && node.querySelector("h1"))),
                     );
 
-                    if (titleChanged || mutation.target.tagName === 'TITLE') {
+                    if (titleChanged || mutation.target.tagName === "TITLE") {
                         setTimeout(updatePageTitle, 50);
                     }
                 }
@@ -88,15 +116,15 @@
         observer.observe(document, {
             childList: true,
             subtree: true,
-            characterData: true
+            characterData: true,
         });
 
         // Also observe the title element specifically
-        const titleElement = document.querySelector('title');
+        const titleElement = document.querySelector("title");
         if (titleElement) {
             observer.observe(titleElement, {
                 childList: true,
-                characterData: true
+                characterData: true,
             });
         }
     }


### PR DESCRIPTION
# Add TypeScript SDK title suffix support

This PR extends the title updater script to support both Python and TypeScript SDK pages. The script now:

- Detects whether the current page is part of the Python or TypeScript SDK documentation
- Applies the appropriate suffix ("| Maxim Python SDK" or "| Maxim TypeScript SDK") based on the SDK type
- Improves title cleanup by handling existing suffixes more robustly
- Maintains consistent formatting with proper spacing between the title and suffix
