### PR TITLE
attachment-fixes-python-version

### DIFF
--- a/tracing/tracing-via-sdk/attachments.mdx
+++ b/tracing/tracing-via-sdk/attachments.mdx
@@ -5,7 +5,7 @@ description: Learn how to attach files and URLs to traces and spans for richer o
 
 <Warning>
 - This feature is currently in beta.
-- Requires `maxim-py` >= 5.6.x
+- Requires `maxim-py` >= 3.9.x
 </Warning>
 
 ## Overview


### PR DESCRIPTION
### TL;DR

Updated the minimum required version of `maxim-py` for the attachments feature.

### What changed?

Changed the minimum required version of `maxim-py` from `>= 5.6.x` to `>= 3.9.x` in the warning section of the attachments documentation.

### How to test?

1. Verify that the attachments feature works correctly with `maxim-py` version 3.9.x
2. Confirm that the documentation accurately reflects the minimum version requirements

### Why make this change?

To correct the version requirement information, ensuring users know they can use the attachments feature with earlier versions of the library (3.9.x) rather than needing the previously stated higher version (5.6.x).