### PR TITLE
fixes dataset entries file payload

### DIFF
--- a/public-apis/openapi/datasets.json
+++ b/public-apis/openapi/datasets.json
@@ -817,12 +817,61 @@
                                 "description": "Type of the data in the column"
                               },
                               "payload": {
-                                "nullable": true
+                                "type": "object",
+                                "properties": {
+                                  "text": {
+                                    "type": "string"
+                                  },
+                                  "files": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string"
+                                        },
+                                        "url": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "id",
+                                        "url"
+                                      ],
+                                      "additionalProperties": false
+                                    }
+                                  }
+                                },
+                                "additionalProperties": false
                               }
                             },
                             "required": [
                               "type"
-                            ]
+                            ],
+                            "if": {
+                              "properties": {
+                                "type": {
+                                  "const": "text"
+                                }
+                              }
+                            },
+                            "then": {
+                              "properties": {
+                                "payload": {
+                                  "required": ["text"],
+                                  "not": {
+                                    "required": ["files"]
+                                  }
+                                }
+                              }
+                            },
+                            "else": {
+                              "properties": {
+                                "payload": {
+                                  "required": ["text", "files"]
+                                }
+                              }
+                            }
                           }
                         },
                         "required": [
@@ -884,7 +933,30 @@
                                       "type": "string"
                                     },
                                     "payload": {
-                                      "type": "string"
+                                      "type": "object",
+                                      "properties": {
+                                        "text": {
+                                          "type": "string"
+                                        },
+                                        "files": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "id": {
+                                                "type": "string"
+                                              },
+                                              "url": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "id",
+                                              "url"
+                                            ]
+                                          }
+                                        }
+                                      }
                                     }
                                   },
                                   "required": [
@@ -1243,12 +1315,58 @@
                                     "type": "string"
                                   },
                                   "payload": {
-                                    "nullable": true
+                                    "type": "object",
+                                    "properties": {
+                                      "text": {
+                                        "type": "string"
+                                      },
+                                      "files": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "id": {
+                                              "type": "string"
+                                            },
+                                            "url": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": ["id", "url"],
+                                          "additionalProperties": false
+                                        }
+                                      }
+                                    },
+                                    "additionalProperties": false
                                   }
                                 },
                                 "required": [
                                   "type"
                                 ],
+                                "if": {
+                                  "properties": {
+                                    "type": {
+                                      "const": "text"
+                                    }
+                                  }
+                                },
+                                "then": {
+                                  "properties": {
+                                    "payload": {
+                                      "required": ["text"],
+                                      "not": {
+                                        "required": ["files"]
+                                      }
+                                    }
+                                  }
+                                },
+                                "else": {
+                                  "properties": {
+                                    "payload": {
+                                      "required": ["text", "files"]
+                                    }
+                                  }
+                                },
                                 "description": "Value of the cell"
                               }
                             },


### PR DESCRIPTION
### TL;DR

Enhanced the payload schema for dataset cells to support both text and file attachments.

### What changed?

- Updated the payload schema in the datasets.json OpenAPI specification to properly define the structure for cell values
- Added conditional validation using JSON Schema if/then/else to enforce different requirements based on cell type:
  - For "text" type: requires "text" property and disallows "files"
  - For other types: requires both "text" and "files" properties
- Added detailed schema for file attachments with required "id" and "url" properties
- Replaced the previous nullable payload with a structured object containing text and optional file references

### How to test?

1. Validate API requests that create or update dataset cells with different payload types
2. Test text-only cells to ensure they accept only the "text" property
3. Test cells with attachments to ensure they require both "text" and "files" properties
4. Verify that file references correctly require both "id" and "url" fields

### Why make this change?

This change provides a more structured and type-safe approach to handling different types of cell data in datasets. By clearly defining the payload schema and adding conditional validation, we improve API documentation, enable better client-side validation, and ensure consistency in how cell data is stored and retrieved.