### PR TITLE
fixed metadata docs

### DIFF
--- a/tracing/tracing-via-sdk/metadata.mdx
+++ b/tracing/tracing-via-sdk/metadata.mdx
@@ -250,37 +250,13 @@ const retrieval = trace.retrieval({
 
 ```python Python
 # Span with metadata
-span = trace.span({
-    "id":"span-id",
-    "name":"data-processing",
-    "metadata":{
-        "data_source": "database",
-        "record_count": 150,
-        "processing_time": "2.3s"
-    }
-})
+span = trace.span(id="span-id", name="data-processing", metadata={"data_source": "database", "record_count": 150, "processing_time": "2.3s"})
 
 # Event with metadata
-event = trace.event({
-    "id":"event-id",
-    "name":"user-action",
-    "metadata":{
-        "action": "button-click",
-        "element_id": "submit-btn",
-        "page_url": "/dashboard"
-    }
-})
+event = trace.event(id="event-id", name="user-action", metadata={"action": "button-click", "element_id": "submit-btn", "page_url": "/dashboard"})
 
 # Retrieval with metadata
-retrieval = trace.retrieval({
-    "id": "retrieval-id",
-    "name": "vector-search",
-    "metadata": {
-        "vector_db": "pinecone",
-        "index_name": "documents",
-        "similarity_threshold": 0.8
-    }
-})
+retrieval = trace.retrieval(id="retrieval-id", name="vector-search",metadata={"vector_db": "pinecone", "index_name": "documents", "similarity_threshold": 0.8})
 ```
 
 ```go Go


### PR DESCRIPTION
### TL;DR

Simplified Python code examples for tracing with metadata.

### What changed?

Updated the Python code examples in the tracing metadata documentation to use a more concise parameter format. Instead of passing dictionaries with nested structures, the examples now use direct keyword arguments for `id` and `name` parameters, with only the `metadata` remaining as a dictionary.

### How to test?

1. Review the updated Python examples in the `tracing/tracing-via-sdk/metadata.mdx` file
2. Verify that the functionality remains the same while the syntax is more straightforward
3. Confirm that all three examples (span, event, and retrieval) follow the same parameter pattern

### Why make this change?

This change improves readability and makes the Python examples more Pythonic by using keyword arguments instead of nested dictionaries. The new format is more consistent with typical Python coding practices and makes the examples easier to understand and implement for Python developers.