### PR TITLE
fixes metadata for traces

### DIFF
--- a/tracing/tracing-via-sdk/metadata.mdx
+++ b/tracing/tracing-via-sdk/metadata.mdx
@@ -112,6 +112,7 @@ trace.add_metadata({
     "custom_key": "custom_value",
     "timestamp": "2024-01-01T00:00:00Z"
 })
+```
 
 ```go Go
 trace := logger.Trace(&logging.TraceConfig{
@@ -150,6 +151,7 @@ const generation = trace.generation({
  });
  
  generation.addMetadata({"promptVersion": "v2.1", "userId": "user-123"});
+ 
  ```
 
 ```python Python


### PR DESCRIPTION
### TL;DR

Fixed code block formatting issues in the metadata documentation.

### What changed?

- Added a missing closing code block delimiter (`\`\`\``) after the Python example
- Added an extra line break after the JavaScript metadata addition example for better readability

### How to test?

1. View the rendered markdown file to ensure code blocks are properly formatted
2. Verify that the Python example now has a proper closing delimiter
3. Check that the JavaScript example has appropriate spacing

### Why make this change?

These formatting fixes ensure proper syntax highlighting and code block rendering in the documentation, improving readability for developers implementing metadata functionality across different programming languages.