### PR TITLE
Add preset configuration documentation for test runs

### DIFF
--- a/offline-evals/via-sdk/agent-http/endpoint-on-maxim.mdx
+++ b/offline-evals/via-sdk/agent-http/endpoint-on-maxim.mdx
@@ -73,6 +73,49 @@ console.log(`Test run completed! View results: ${result.testRunResult.link}`);
 
 </CodeGroup>
 
+## Using Presets
+
+If you have saved test configuration presets on the Maxim platform, you can use them to automatically load datasets, evaluators, and other settings without specifying them manually:
+
+```python Python
+from maxim import Maxim
+
+maxim = Maxim({"api_key": "your-api-key"})
+
+# Test using a saved preset — dataset, evaluators, and context
+# settings are loaded from the preset automatically
+result = (
+    maxim.create_test_run(
+        name="Workflow Test with Preset",
+        in_workspace_id="your-workspace-id",
+    )
+    .with_workflow_id("your-workflow-id")
+    .with_preset("My Saved Preset")
+    .run()
+)
+
+print(f"Test completed! View results: {result.test_run_result.link}")
+```
+
+Any values you set explicitly via other builder methods will take priority over the preset defaults:
+
+```python Python
+result = (
+    maxim.create_test_run(
+        name="Workflow Test with Preset Override",
+        in_workspace_id="your-workspace-id",
+    )
+    .with_workflow_id("your-workflow-id")
+    .with_preset("My Saved Preset")
+    .with_data("different-dataset-id")  # Overrides the preset's dataset
+    .run()
+)
+```
+
+<Note>
+  If the preset includes human evaluators, you must also call `with_human_evaluation_config` to provide the reviewer emails.
+</Note>
+
 ## Next Steps
 
 - [Local Endpoint Testing](/offline-evals/via-sdk/agent-http/local-endpoint) - Test agents with custom HTTP endpoints

--- a/offline-evals/via-sdk/agent-no-code/agent-on-maxim.mdx
+++ b/offline-evals/via-sdk/agent-no-code/agent-on-maxim.mdx
@@ -65,6 +65,49 @@ console.log(`Test run completed! View results: ${result.testRunResult.link}`);
 
 </CodeGroup>
 
+## Using Presets
+
+If you have saved test configuration presets on the Maxim platform, you can use them to automatically load datasets, evaluators, and other settings without specifying them manually:
+
+```python Python
+from maxim import Maxim
+
+maxim = Maxim({"api_key": "your-api-key"})
+
+# Test using a saved preset — dataset, evaluators, and context
+# settings are loaded from the preset automatically
+result = (
+    maxim.create_test_run(
+        name="No-code Agent Test with Preset",
+        in_workspace_id="your-workspace-id",
+    )
+    .with_prompt_chain_version_id("your-prompt-chain-version-id")
+    .with_preset("My Saved Preset")
+    .run()
+)
+
+print(f"Test completed! View results: {result.test_run_result.link}")
+```
+
+Any values you set explicitly via other builder methods will take priority over the preset defaults:
+
+```python Python
+result = (
+    maxim.create_test_run(
+        name="No-code Agent Test with Preset Override",
+        in_workspace_id="your-workspace-id",
+    )
+    .with_prompt_chain_version_id("your-prompt-chain-version-id")
+    .with_preset("My Saved Preset")
+    .with_data("different-dataset-id")  # Overrides the preset's dataset
+    .run()
+)
+```
+
+<Note>
+  If the preset includes human evaluators, you must also call `with_human_evaluation_config` to provide the reviewer emails.
+</Note>
+
 ## Next Steps
 
 - [Local Agent Testing](/offline-evals/via-sdk/local-agent) - Learn how to create custom agents with local logic

--- a/offline-evals/via-sdk/prompts/maxim-prompt.mdx
+++ b/offline-evals/via-sdk/prompts/maxim-prompt.mdx
@@ -72,6 +72,50 @@ console.log(`Test completed! View results: ${result.testRunResult.link}`);
 
 </CodeGroup>
 
+## Using Presets
+
+If you have saved test configuration presets on the Maxim platform, you can use them to automatically load datasets, evaluators, and other settings without specifying them manually. Use the `with_preset` function with the preset name:
+
+```python Python
+from maxim import Maxim
+
+# Initialize Maxim SDK
+maxim = Maxim({"api_key": "your-maxim-api-key"})
+
+# Test using a saved preset — dataset, evaluators, and context
+# settings are loaded from the preset automatically
+result = (
+    maxim.create_test_run(
+        name="Prompt Test with Preset",
+        in_workspace_id="your-workspace-id",
+    )
+    .with_prompt_version_id("prompt-version-id")
+    .with_preset("My Saved Preset")
+    .run()
+)
+
+print(f"Test completed! View results: {result.test_run_result.link}")
+```
+
+The preset provides default values for datasets, evaluators, context-to-evaluate settings, and simulation config. Any values you set explicitly via other builder methods will take priority over the preset defaults. For example, you can override the preset's dataset while keeping its evaluators:
+
+```python Python
+result = (
+    maxim.create_test_run(
+        name="Prompt Test with Preset Override",
+        in_workspace_id="your-workspace-id",
+    )
+    .with_prompt_version_id("prompt-version-id")
+    .with_preset("My Saved Preset")
+    .with_data("different-dataset-id")  # Overrides the preset's dataset
+    .run()
+)
+```
+
+<Note>
+  If the preset includes human evaluators, you must also call `with_human_evaluation_config` to provide the reviewer emails.
+</Note>
+
 ## Important Notes
 
 1. **Variable Mapping**: Ensure that variable names in your testing data match the variable names defined in your Maxim prompt.

--- a/sdk/python/references/test_runs/test_run_builder.mdx
+++ b/sdk/python/references/test_runs/test_run_builder.mdx
@@ -216,6 +216,32 @@ When used with `yields_output()`, the SDK runs your output function locally in a
 
 - `ValueError` - If simulation config is used with `with_prompt_chain_version_id` (use `with_workflow_id` or `with_prompt_version_id` instead)
 
+#### with\_preset
+
+```python
+def with_preset(preset_name: str) -> "TestRunBuilder[T]"
+```
+
+Set a preset (test configuration) to use for this test run. The preset provides default values for datasets, evaluators, simulation config, and context-to-evaluate settings. Any values explicitly set via other builder methods will take priority over preset defaults.
+
+Requires an entity to be set first via `with_workflow_id()`, `with_prompt_version_id()`, or `with_prompt_chain_version_id()`, as the preset is scoped to a specific entity.
+
+**Arguments**:
+
+| Name | Type | Description |
+|------|------|-------------|
+| `preset_name` | _str_ | The name of the preset (test config) saved on the Maxim platform |
+
+**Returns**:
+
+| Name | Description |
+|------|-------------|
+| `[TestRunBuilder](/sdk/python/references/test_runs/test_run_builder)[T]` | The current TestRunBuilder instance for method chaining |
+
+**Raises**:
+
+- `ValueError` - If preset_name is empty or not a string
+
 #### yields\_output
 
 ```python


### PR DESCRIPTION
This pull request adds preset functionality to the Maxim SDK, allowing users to leverage saved test configurations from the platform. The changes introduce a new `with_preset()` method to the TestRunBuilder that accepts a preset name and automatically loads associated datasets, evaluators, and other settings.

Key additions include:

- New `with_preset()` method in the TestRunBuilder class that takes a preset name parameter
- Documentation showing how to use presets with workflow endpoints, no-code agents, and prompts
- Examples demonstrating preset override behavior where explicit method calls take precedence over preset defaults
- Notes about handling human evaluators when using presets that include them
- Error handling for invalid preset names and empty strings

The preset functionality requires an entity to be set first (workflow, prompt version, or prompt chain version) since presets are scoped to specific entities. This feature streamlines test configuration by eliminating the need to manually specify datasets, evaluators, and settings that have been previously saved as presets on the platform.