### PR TITLE
Add `HttpWorkflowConfig` and `VoiceWorkflowConfig` schemas to Workflows OpenAPI spec

### DIFF
--- a/public-apis/openapi/workflows.json
+++ b/public-apis/openapi/workflows.json
@@ -72,6 +72,233 @@
           "createdAt",
           "updatedAt"
         ]
+      },
+      "HttpWorkflowConfig": {
+        "type": "object",
+        "description": "Configuration for HTTP workflows. All fields are optional in update payloads (partial schema applied server-side).",
+        "properties": {
+          "scheme": {
+            "type": "string",
+            "enum": [
+              "https",
+              "wss"
+            ],
+            "description": "Transport scheme"
+          },
+          "method": {
+            "type": "string",
+            "enum": [
+              "GET",
+              "POST",
+              "PUT",
+              "DELETE",
+              "PATCH"
+            ],
+            "description": "HTTP method"
+          },
+          "url": {
+            "type": "string",
+            "description": "Endpoint URL"
+          },
+          "params": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "key": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "value": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "key",
+                "value"
+              ]
+            },
+            "description": "Query parameters"
+          },
+          "headers": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "key": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "value": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "key",
+                "value"
+              ]
+            },
+            "description": "HTTP headers"
+          },
+          "payload": {
+            "type": "string",
+            "description": "Request body payload (string; JSON should be pre-stringified)"
+          },
+          "output": {
+            "type": "string",
+            "description": "Response output mapping expression"
+          },
+          "scripts": {
+            "type": "string",
+            "description": "Pre/post request scripts"
+          },
+          "authentication": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "none"
+                    ]
+                  }
+                },
+                "required": [
+                  "type"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "aws4"
+                    ]
+                  },
+                  "accessKeyId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "secretAccessKey": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "sessionToken": {
+                    "type": "string"
+                  },
+                  "region": {
+                    "type": "string"
+                  },
+                  "service": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "accessKeyId",
+                  "secretAccessKey"
+                ]
+              }
+            ],
+            "description": "Authentication strategy: 'none' or AWS Signature V4 ('aws4')."
+          },
+          "timeout": {
+            "type": "number",
+            "description": "Request timeout in seconds"
+          },
+          "concurrency": {
+            "type": "number",
+            "default": 10,
+            "description": "Maximum concurrent requests"
+          },
+          "maxRetries": {
+            "type": "number",
+            "minimum": 0,
+            "default": 3,
+            "description": "Maximum retry attempts"
+          },
+          "contextToEvaluate": {
+            "type": "string",
+            "description": "Context expression evaluated against the response"
+          },
+          "variables": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Variable substitutions used in url, payload, headers, etc."
+          },
+          "environmentId": {
+            "type": "string",
+            "description": "Environment identifier used to resolve variables"
+          }
+        }
+      },
+      "VoiceWorkflowConfig": {
+        "type": "object",
+        "description": "Configuration for VOICE workflows. All fields are optional in update payloads (partial schema applied server-side).",
+        "properties": {
+          "phoneNumber": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Phone number (national portion, without dial code)"
+          },
+          "countryCode": {
+            "type": "string",
+            "description": "ISO 3166-1 alpha-2 country code (e.g., US, GB)"
+          },
+          "country": {
+            "type": "string",
+            "description": "Country name (display only)"
+          },
+          "dialCode": {
+            "type": "string",
+            "minLength": 1,
+            "description": "International dial code (e.g., +1)"
+          },
+          "timeout": {
+            "type": "number",
+            "description": "Call timeout in seconds"
+          },
+          "concurrency": {
+            "type": "number",
+            "default": 10,
+            "description": "Maximum concurrent calls"
+          },
+          "contextToEvaluate": {
+            "type": "string",
+            "description": "Context expression evaluated against the call output"
+          },
+          "maxRetries": {
+            "type": "number",
+            "minimum": 0,
+            "default": 3,
+            "description": "Maximum retry attempts"
+          },
+          "variables": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Variable substitutions"
+          },
+          "language": {
+            "type": "string",
+            "description": "Language/locale code (e.g., en-US)"
+          }
+        }
       }
     },
     "parameters": {}
@@ -427,11 +654,15 @@
                     "description": "Move the workflow to this workspace. Omit to keep it in the current workspace."
                   },
                   "config": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "nullable": true
-                    },
-                    "description": "Partial workflow config. Top-level keys are shallow-merged with the existing config; nested objects/arrays are replaced, not merged."
+                    "oneOf": [
+                      {
+                        "$ref": "#/components/schemas/HttpWorkflowConfig"
+                      },
+                      {
+                        "$ref": "#/components/schemas/VoiceWorkflowConfig"
+                      }
+                    ],
+                    "description": "Partial workflow config. Shape depends on the workflow's stored type (HTTP or VOICE) — supply the matching schema. Top-level keys are shallow-merged with the existing config; nested objects/arrays are replaced, not merged."
                   },
                   "evalConfig": {
                     "type": "object",


### PR DESCRIPTION
## Add `HttpWorkflowConfig` and `VoiceWorkflowConfig` schemas to the Workflows OpenAPI spec

Replaces the loosely-typed `config` field (previously `additionalProperties: nullable`) in the workflow update endpoint with a `oneOf` reference to two new, fully-documented schemas:

- **`HttpWorkflowConfig`** — covers HTTP/WebSocket workflows, including `scheme`, `method`, `url`, `params`, `headers`, `payload`, `output`, `scripts`, `authentication` (`none` or AWS Signature V4), `timeout`, `concurrency`, `maxRetries`, `contextToEvaluate`, `variables`, and `environmentId`.
- **`VoiceWorkflowConfig`** — covers voice/call workflows, including `phoneNumber`, `countryCode`, `country`, `dialCode`, `timeout`, `concurrency`, `maxRetries`, `contextToEvaluate`, `variables`, and `language`.

Both schemas treat all fields as optional to support partial update payloads, consistent with the existing shallow-merge behavior described in the endpoint documentation.